### PR TITLE
Simplify internal event messages for code readability

### DIFF
--- a/arson-warehouse/browser-extension/dist/background.js
+++ b/arson-warehouse/browser-extension/dist/background.js
@@ -3,10 +3,6 @@ chrome.management.getSelf((extensionInfo) => {
     window.dev = extensionInfo.installType === 'development';
 });
 
-window.userAgentNeedsListener =
-    userAgentContains('YaBrowser') // For Yandex (both Android and desktop)
-    || userAgentContains('Mobile Safari'); // For Android Kiwi
-
 chrome.browserAction.onClicked.addListener(async (tab) => {
     if (tab.url.indexOf('trade.php') === -1) {
         showAlertInTab(tab, 'ArsonWarehouse shows you the total value for a trade.\n\nView a trade and then press this button.');
@@ -14,7 +10,7 @@ chrome.browserAction.onClicked.addListener(async (tab) => {
     }
 
     try {
-        const tradeId = +tab.url.match(/ID=(\d+)/)[1];
+        const tradeId = parseInt(tab.url.match(/ID=(\d+)/)[1], 10);
         const tradeDataFromPage = await getTradeDataFromPage(tab);
         const tradeValueResponse = await fetchTradeValue(tradeId, tradeDataFromPage);
         emitTradeValueResponse(tab, tradeValueResponse);
@@ -29,71 +25,45 @@ chrome.runtime.onMessage.addListener((message) => {
     }
 });
 
-function sendEquipmentReportToArsonWarehouse(report) {
-    return fetch(getBaseUrl() + '/api/v1/equipment-reports', {
-        headers: new Headers({
-            Authorization: 'Basic ' + btoa(`${report.reporterId}:`),
-        }),
-        method: 'post',
-        body: JSON.stringify(report.equipment),
-    });
-}
-
 function getTradeDataFromPage(tab) {
-    if (window.userAgentNeedsListener) {
-        return getTradeDataWithListener(tab);
-    }
-
     return new Promise((resolve) => {
-        chrome.tabs.sendMessage(tab.id, {action: 'get-trade-data'}, resolve);
-    });
-}
-
-function getTradeDataWithListener(tab) {
-    return new Promise((resolve) => {
-        const oneTimeResponseHandler = (message) => {
+        const didGetTradeDataHandler = (message) => {
             if (message.action === 'did-get-trade-data') {
                 resolve(message.payload);
+                chrome.runtime.onMessage.removeListener(didGetTradeDataHandler);
             }
-            chrome.runtime.onMessage.removeListener(oneTimeResponseHandler);
         };
-        chrome.runtime.onMessage.addListener(oneTimeResponseHandler);
+        chrome.runtime.onMessage.addListener(didGetTradeDataHandler);
         chrome.tabs.sendMessage(tab.id, {action: 'get-trade-data'});
     });
 }
 
-function fetchTradeValue(tradeId, tradeData) {
+async function fetchTradeValue(tradeId, tradeData) {
     if (tradeData.currentUserItems.length + tradeData.otherUserItems.length === 0) {
-        throw createErrorWithFriendlyMessage('Neither side contains items.');
+        throw errorWithFriendlyMessage('Neither side contains items.');
     }
     if (tradeData.currentUserItems.length > 0 && tradeData.otherUserItems.length > 0) {
-        throw createErrorWithFriendlyMessage('Both sides contain items - this is not supported.');
+        throw errorWithFriendlyMessage('Both sides contain items - this is not supported.');
     }
 
-    const requestBody = getRequestBody(tradeId, tradeData);
-
-    return fetch(getBaseUrl() + '/api/v1/trades', {method: 'post', body: JSON.stringify(requestBody)}).then(async (response) => {
-        if (response.status === 200) {
-            return response.json()
-        }
-        if (response.status === 400) {
-            const responseJson = await response.json();
-            if (typeof responseJson.reason === 'string' && responseJson.reason.length > 0) {
-                throw createErrorWithFriendlyMessage(responseJson.reason);
-            }
-        }
-        throw createErrorWithFriendlyMessage('Something went wrong on the ArsonWarehouse server (or the service is temporarily down).');
+    const response = await fetch(getBaseUrl() + '/api/v1/trades', {
+        method: 'post',
+        body: JSON.stringify(getTradeRequestBody(tradeId, tradeData)),
     });
+
+    if (response.status === 400) {
+        const responseJson = await response.json();
+        if (typeof responseJson.reason === 'string' && responseJson.reason.length > 0) {
+            throw errorWithFriendlyMessage(responseJson.reason);
+        }
+    } else if (response.status !== 200) {
+        throw errorWithFriendlyMessage('Something went wrong on the ArsonWarehouse server (or the service is temporarily down).');
+    }
+
+    return response.json();
 }
 
-function emitTradeValueResponse(tab, tradeValueResponse) {
-    chrome.tabs.sendMessage(tab.id, {
-        action: 'did-get-trade-value-response',
-        payload: tradeValueResponse,
-    });
-}
-
-function getRequestBody(tradeId, tradeData) {
+function getTradeRequestBody(tradeId, tradeData) {
     const requestBody = {
         trade_id: tradeId,
         plugin_version: chrome.runtime.getManifest().version,
@@ -113,8 +83,21 @@ function getRequestBody(tradeId, tradeData) {
     return requestBody;
 }
 
-function userAgentContains(search) {
-    return navigator.userAgent.indexOf(search) > -1;
+function emitTradeValueResponse(tab, tradeValueResponse) {
+    chrome.tabs.sendMessage(tab.id, {
+        action: 'did-get-trade-value-response',
+        payload: tradeValueResponse,
+    });
+}
+
+function sendEquipmentReportToArsonWarehouse(report) {
+    return fetch(getBaseUrl() + '/api/v1/equipment-reports', {
+        headers: new Headers({
+            Authorization: 'Basic ' + btoa(`${report.reporterId}:`),
+        }),
+        method: 'post',
+        body: JSON.stringify(report.equipment),
+    });
 }
 
 function showAlertInTab(tab, message) {
@@ -123,7 +106,7 @@ function showAlertInTab(tab, message) {
     });
 }
 
-function createErrorWithFriendlyMessage(message) {
+function errorWithFriendlyMessage(message) {
     const error = new Error(message);
     error.hasFriendlyMessage = true;
     return error;

--- a/arson-warehouse/browser-extension/dist/background.js
+++ b/arson-warehouse/browser-extension/dist/background.js
@@ -46,21 +46,25 @@ async function fetchTradeValue(tradeId, tradeData) {
         throw errorWithFriendlyMessage('Both sides contain items - this is not supported.');
     }
 
-    const response = await fetch(getBaseUrl() + '/api/v1/trades', {
-        method: 'post',
-        body: JSON.stringify(getTradeRequestBody(tradeId, tradeData)),
-    });
+    try {
+        const response = await fetch(getBaseUrl() + '/api/v1/trades', {
+            method: 'post',
+            body: JSON.stringify(getTradeRequestBody(tradeId, tradeData)),
+        });
 
-    if (response.status === 400) {
-        const responseJson = await response.json();
-        if (typeof responseJson.reason === 'string' && responseJson.reason.length > 0) {
-            throw errorWithFriendlyMessage(responseJson.reason);
+        if (response.status === 400) {
+            const responseJson = await response.json();
+            if (typeof responseJson.reason === 'string' && responseJson.reason.length > 0) {
+                throw errorWithFriendlyMessage(responseJson.reason);
+            }
+        } else if (response.status !== 200) {
+            throw errorWithFriendlyMessage('Something went wrong on the ArsonWarehouse server (or the service is temporarily down).');
         }
-    } else if (response.status !== 200) {
-        throw errorWithFriendlyMessage('Something went wrong on the ArsonWarehouse server (or the service is temporarily down).');
-    }
 
-    return response.json();
+        return response.json();
+    } catch (error) {
+        throw errorWithFriendlyMessage(error.message + ' - Please make sure the plugin has permission to access arsonwarehouse.com.');
+    }
 }
 
 function getTradeRequestBody(tradeId, tradeData) {

--- a/arson-warehouse/browser-extension/dist/js/content-scripts/trade/trade.js
+++ b/arson-warehouse/browser-extension/dist/js/content-scripts/trade/trade.js
@@ -1,4 +1,4 @@
-global.tradeValueModalVue = null;
+global.tradeValueModalVueInstance = null;
 
 (async function () {
     if (window.location.search.indexOf('money=') > -1) {
@@ -14,41 +14,66 @@ global.tradeValueModalVue = null;
     }
 })();
 
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-    if (message.action === 'get-trade-data') {
-        const tradeModalVueRoot = document.createElement('div');
-        tradeModalVueRoot.className = 'awh-trade-modal-vue-root';
-        tradeModalVueRoot.setAttribute('v-cloak', '');
-        tradeModalVueRoot.innerHTML = '<trade-modal @close="closeTradeModal" :trade-value-response="tradeValueResponse"></trade-modal>';
-        document.body.appendChild(tradeModalVueRoot);
-
-        global.tradeValueModalVue = new global.Vue({
-            el: tradeModalVueRoot,
-            data() {
-                return {
-                    tradeValueResponse: null,
-                };
-            },
-            created() {
-                document.documentElement.classList.add('awh-modal-is-open');
-            },
-            methods: {
-                closeTradeModal() {
-                    global.tradeValueModalVue = null;
-                    document.documentElement.classList.remove('awh-modal-is-open');
-                    this.$el.remove();
-                    this.$destroy();
-                },
-            },
-        });
-
-        return browserAgnosticResponse(getTradeData(), sendResponse);
-    }
-
-    if (message.action === 'did-get-trade-value-response' && global.tradeValueModalVue !== null) {
-        global.tradeValueModalVue.tradeValueResponse = message.payload;
+chrome.runtime.onMessage.addListener((message) => {
+    switch (message.action) {
+        case 'get-trade-data':
+            onGetTradeData();
+            break;
+        case 'did-get-trade-value-response':
+            if (global.tradeValueModalVueInstance !== null) {
+                onDidGetTradeValueResponse(message.payload);
+            }
+            break;
     }
 });
+
+function onGetTradeData() {
+    global.tradeValueModalVueInstance = createTradeModalVueInstance();
+
+    getTradeData().then((tradeData) => {
+        chrome.runtime.sendMessage({
+            action: 'did-get-trade-data',
+            payload: tradeData,
+        });
+    });
+}
+
+function createTradeModalVueInstance() {
+    const tradeModalVueRoot = createTradeModalVueRoot();
+    document.body.appendChild(tradeModalVueRoot);
+
+    return new global.Vue({
+        el: tradeModalVueRoot,
+        data() {
+            return {
+                tradeValueResponse: null,
+            };
+        },
+        created() {
+            document.documentElement.classList.add('awh-modal-is-open');
+        },
+        methods: {
+            closeTradeModal() {
+                global.tradeValueModalVueInstance = null;
+                document.documentElement.classList.remove('awh-modal-is-open');
+                this.$el.remove();
+                this.$destroy();
+            },
+        },
+    });
+}
+
+function createTradeModalVueRoot() {
+    const tradeModalVueRoot = document.createElement('div');
+    tradeModalVueRoot.className = 'awh-trade-modal-vue-root';
+    tradeModalVueRoot.setAttribute('v-cloak', '');
+    tradeModalVueRoot.innerHTML = '<trade-modal @close="closeTradeModal" :trade-value-response="tradeValueResponse"></trade-modal>';
+    return tradeModalVueRoot;
+}
+
+function onDidGetTradeValueResponse(tradeValueResponse) {
+    global.tradeValueModalVueInstance.tradeValueResponse = tradeValueResponse;
+}
 
 async function getTradeData() {
     const tradeWindow = await truthy(() => document.querySelector('.trade-cont'));
@@ -56,19 +81,12 @@ async function getTradeData() {
     const currentUserSide = new TradeSide(tradeWindow.querySelector('.trade-cont .user.left'));
     const otherUserSide = new TradeSide(tradeWindow.querySelector('.trade-cont .user.right'));
 
-    const tradeData = {
+    return {
         currentUserId: getUserIdFromCookie(),
         currentUserItems: currentUserSide.getItems().map(item => item.getApiRequestData()),
         otherUserName: otherUserSide.getUserName(),
         otherUserItems: otherUserSide.getItems().map(item => item.getApiRequestData()),
     };
-
-    chrome.runtime.sendMessage({
-        action: 'did-get-trade-data',
-        payload: tradeData,
-    });
-
-    return tradeData;
 }
 
 function truthy(handler) {
@@ -83,14 +101,6 @@ function truthy(handler) {
         };
         resolveIfHandlerReturnsTruthy();
     });
-}
-
-function browserAgnosticResponse(promise, sendResponse) {
-    // For chrome, invoke sendResponse when the promise resolves:
-    promise.then(sendResponse);
-
-    // For firefox, return the promise:
-    return promise;
 }
 
 function getUserIdFromCookie() {


### PR DESCRIPTION
There used to be separate code branches for chrome, firefox, and yandex+kiwi. This PR merges them all into a single approach to simplify the code and make it easier to reason about.

It also responds properly to a failed network request in case the user denied the plugin access to arsonwarehouse.com (most likely scenario for a network request to fail):

![image](https://user-images.githubusercontent.com/51235201/76689487-91497900-6636-11ea-90f7-4f51f5535ba4.png)
